### PR TITLE
feat!: introduce new conventions

### DIFF
--- a/generateContentfulTypes.js
+++ b/generateContentfulTypes.js
@@ -7,11 +7,14 @@ const fs = require('fs')
 const path = require('path')
 const Rx = require('rx')
 
-const toInterfaceName = (s, prefix = '') => {
-  s.replace(/-[[:alnum:]]/gm, (match) => { console.log('Match', match); return match.slice(1).toUpperCase()})
-  return prefix + s.charAt(0).toUpperCase() + s.slice(1)
-    .replace(/-[A-Za-z0-9_]/g, (match) => match.slice(1).toUpperCase())
-}
+const toPascalCase = (s, prefix = '') => {
+    s.replace(/-[[:alnum:]]/gm, (match) => { console.log('Match', match); return match.slice(1).toUpperCase()})
+    return prefix + s.charAt(0).toUpperCase() + s.slice(1)
+      .replace(/-[A-Za-z0-9_]/g, (match) => match.slice(1).toUpperCase())
+  }
+
+const getConstantName = (id, prefix) => `${toPascalCase(id, prefix)}Name`;
+const getInterfaceName = (id, prefix) => `I${toPascalCase(id, prefix)}`;
 
 const relativePath = path.normalize(path.relative(process.cwd(), __dirname))
 
@@ -22,9 +25,9 @@ const formatArray = (isArray, typeName) => isArray ? `ReadonlyArray<${typeName}>
 const concatLinkTypes = (prefix, linkContentType) =>
   Array.isArray(linkContentType)
     ? linkContentType.map(type => {
-        return toInterfaceName(type, prefix)
+        return toPascalCase(type, prefix)
       }).join('|')
-    : toInterfaceName(linkContentType, prefix)
+    : toPascalCase(linkContentType, prefix)
 
 const formatType = (field, prefix = '', isArray = false) => {
   const type = field.type
@@ -80,9 +83,9 @@ const writeTypesToFile = (types, outputFilePath, prefix, ignoredFields = [] ) =>
   var stream = fs.createWriteStream(outputFilePath)
   stream.once('open', () => {
     stream.write(`import { Entry, Asset } from 'contentful'\n`)
-    items.sort((a, b) => toInterfaceName(a.sys.id, prefix).localeCompare(toInterfaceName(b.sys.id, prefix))).forEach(item => {
-        stream.write(`export const ${toInterfaceName(item.sys.id, prefix)} = '${item.sys.id}'\n`)
-        stream.write(`export interface ${toInterfaceName(item.sys.id, prefix)} {\n`)
+    items.sort((a, b) => toPascalCase(a.sys.id, prefix).localeCompare(toPascalCase(b.sys.id, prefix))).forEach(item => {
+        stream.write(`export const ${getConstantName(item.sys.id, prefix)} = '${item.sys.id}'\n`)
+        stream.write(`export interface ${getInterfaceName(item.sys.id, prefix)} {\n`)
         stream.write(`  //${item.name}\n`)
         stream.write(`  /* ${item.description} */\n`)
         item.fields.sort((a, b) => a.id.localeCompare(b.id)).forEach(field => {


### PR DESCRIPTION
## Description
Both the constant and interface are exported, but currently use the same naming. This makes is difficult to use the name as a constant. I faced this issue when using the `type Entry` and extending it based on my custom one. Even though, I ended up using a different approach, I think it might be better if we use a different name for the interface and constant.

I tested it on my own project generating the types and it works. If you think is a good change, feel free to merge it. However, please ensure to do some additional testing using the script before merging (running the script).

Additionally, I think it would be nice if we add a test to this script, to ensure it does what is expected. However, I left that out of scope of this pull request.

**Current situation:**

![Screenshot 2024-05-06 at 18 56 22](https://github.com/arimkevi/contentful-ts-type-generator/assets/8817968/fefa4d8d-d064-4221-8907-ee064bf964a9)

**Expected:**

![Screenshot 2024-05-06 at 18 56 15](https://github.com/arimkevi/contentful-ts-type-generator/assets/8817968/2efd6737-9507-48f5-93ee-ff3df09624d0)


## Changes

BREAKING CHANGE: Changed naming convention so that both the exported constant name and interface can be used

- rename `toInterfaceName` to `toPascalCase`
- introduced `getInterfaceName` method to prefix interface names with `I`
- introduced `getConstantName` method to postfix constants with `Name`